### PR TITLE
[Fix] Adjusting category creation validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
 		<dependency>
 			<groupId>com.peralta.cashflow</groupId>
 			<artifactId>cashflow-auth</artifactId>
-			<version>1.0.4</version>
+			<version>1.0.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.peralta.cashflow</groupId>

--- a/src/main/java/com/cashflow/coredata/domain/mapper/category/CategoryMapper.java
+++ b/src/main/java/com/cashflow/coredata/domain/mapper/category/CategoryMapper.java
@@ -1,24 +1,21 @@
 package com.cashflow.coredata.domain.mapper.category;
 
-import com.cashflow.auth.core.domain.authentication.CashFlowAuthentication;
 import com.cashflow.coredata.domain.dto.request.category.CategoryCreationRequest;
 import com.cashflow.coredata.domain.dto.response.CategoryResponse;
 import com.cashflow.coredata.domain.entities.Category;
-
-import java.util.Objects;
 
 public class CategoryMapper {
 
     private CategoryMapper(){}
 
-    public static Category mapToEntity(CategoryCreationRequest request, CashFlowAuthentication authentication) {
+    public static Category mapToEntity(CategoryCreationRequest request, Long userId) {
         return new Category(
                 null,
                 request.name(),
                 request.color(),
                 request.icon(),
                 true,
-                Objects.requireNonNull(authentication.getCredentials()).id()
+                userId
         );
     }
 

--- a/src/main/java/com/cashflow/coredata/repository/category/CategoryRepository.java
+++ b/src/main/java/com/cashflow/coredata/repository/category/CategoryRepository.java
@@ -11,7 +11,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     @Query(value = "SELECT EXISTS (" +
             "SELECT * FROM tb_category category " +
             "WHERE UPPER(category.name) = UPPER(:name) " +
+            "AND category.user_id = :userId " +
             "AND category.active = true)", nativeQuery = true)
-    Long existsByNameIgnoreCase(String name);
+    Long existsByNameIgnoreCase(String name, Long userId);
 
 }

--- a/src/main/java/com/cashflow/coredata/service/category/CategoryService.java
+++ b/src/main/java/com/cashflow/coredata/service/category/CategoryService.java
@@ -1,6 +1,6 @@
 package com.cashflow.coredata.service.category;
 
-import com.cashflow.auth.core.domain.authentication.CashFlowAuthentication;
+import com.cashflow.auth.core.utils.AuthUtils;
 import com.cashflow.commons.core.dto.request.BaseRequest;
 import com.cashflow.coredata.domain.dto.request.category.CategoryCreationRequest;
 import com.cashflow.coredata.domain.dto.response.CategoryResponse;
@@ -12,10 +12,7 @@ import com.cashflow.exception.core.CashFlowException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-
-import java.util.Objects;
 
 @Service
 public class CategoryService implements ICategoryService {
@@ -36,16 +33,17 @@ public class CategoryService implements ICategoryService {
     public CategoryResponse registerCategory(BaseRequest<CategoryCreationRequest> baseRequest) throws CashFlowException {
 
         CategoryCreationRequest request = baseRequest.getRequest();
+        Long userId = AuthUtils.getUserIdFromSecurityContext();
 
         CategoryValidator.validateCategoryCreation(
-                categoryExistsByName(request.name()),
+                categoryExistsByName(request.name(), userId),
                 messageSource,
                 baseRequest.getLanguage()
         );
 
         Category category = categoryRepository.save(CategoryMapper.mapToEntity(
                 request,
-                (CashFlowAuthentication) Objects.requireNonNull(SecurityContextHolder.getContext().getAuthentication())
+                userId
         ));
 
         log.info("Category created successfully!");
@@ -54,8 +52,8 @@ public class CategoryService implements ICategoryService {
 
     }
 
-    private boolean categoryExistsByName(String name) {
-        return categoryRepository.existsByNameIgnoreCase(name) == 1;
+    private boolean categoryExistsByName(String name, Long userId) {
+        return categoryRepository.existsByNameIgnoreCase(name, userId) == 1;
     }
 
 }


### PR DESCRIPTION
## 💬 Description

Category name validation should consider `userId` because different users can have categories with the same name managed by each user.

## 📋 What was done

- Updated `auth-lib` version;
- Added userId from `SecurityContext` to validate and generate new categories;
- Update on unit tests;

## 🛠️ Build

<img width="1360" height="714" alt="image" src="https://github.com/user-attachments/assets/3ff79093-b900-4593-91a0-947642949de5" />

## 👷 Working Locally

### When category with name and ID already exists

<img width="1897" height="773" alt="UserIdAlreadyExists" src="https://github.com/user-attachments/assets/587d8c4f-09cc-4233-b452-93aad1e59270" />

### When category with name already exists but not with the same ID

<img width="1911" height="934" alt="UserIdDoNotExists" src="https://github.com/user-attachments/assets/335a8a63-411c-472d-9544-434b64ff04f8" />