### PR TITLE
[Feature] Implement REDIS for caching list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
 		<dependency>
 			<groupId>com.peralta.cashflow</groupId>
 			<artifactId>cashflow-commons</artifactId>
-			<version>0.0.3</version>
+			<version>0.0.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.peralta.cashflow</groupId>
@@ -181,6 +181,11 @@
 			<groupId>com.peralta.cashflow</groupId>
 			<artifactId>cashflow-exceptions</artifactId>
 			<version>1.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.peralta.cashflow</groupId>
+			<artifactId>cashflow-cache</artifactId>
+			<version>1.0.0</version>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/com/cashflow/coredata/config/CacheDurationConfig.java
+++ b/src/main/java/com/cashflow/coredata/config/CacheDurationConfig.java
@@ -1,0 +1,24 @@
+package com.cashflow.coredata.config;
+
+import com.cashflow.coredata.utils.constants.cache.CacheNames;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Configuration
+public class CacheDurationConfig {
+
+    @Value("${cache.duration.categories}")
+    private Long categoriesCacheDuration;
+
+    @Bean
+    public Map<String, Duration> cacheDurations() {
+        return Map.of(
+                CacheNames.CATEGORIES, Duration.ofMinutes(categoriesCacheDuration)
+        );
+    }
+
+}

--- a/src/main/java/com/cashflow/coredata/controller/category/CategoryController.java
+++ b/src/main/java/com/cashflow/coredata/controller/category/CategoryController.java
@@ -1,7 +1,9 @@
 package com.cashflow.coredata.controller.category;
 
+import com.cashflow.auth.core.utils.AuthUtils;
 import com.cashflow.commons.core.dto.request.BaseRequest;
 import com.cashflow.commons.core.dto.request.PageRequest;
+import com.cashflow.commons.core.dto.response.PageResponse;
 import com.cashflow.coredata.domain.dto.request.category.CategoryCreationRequest;
 import com.cashflow.coredata.domain.dto.response.CategoryResponse;
 import com.cashflow.coredata.service.category.ICategoryService;
@@ -9,7 +11,6 @@ import com.cashflow.exception.core.CashFlowException;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,16 +35,20 @@ public class CategoryController implements ICategoryController {
     @PostMapping
     public CategoryResponse registerCategory(CategoryCreationRequest request, Locale language) throws CashFlowException {
         log.info("Received request to register a new category with name: {}", request.name());
-        return categoryService.registerCategory(new BaseRequest<>(language, request));
+        return categoryService.registerCategory(
+                new BaseRequest<>(language, request),
+                AuthUtils.getUserIdFromSecurityContext()
+        );
     }
 
     @Override
     @GetMapping("/list")
-    public Page<CategoryResponse> listCategories(Locale language, int pageNumber, int pageSize, String search) {
+    public PageResponse<CategoryResponse> listCategories(Locale language, int pageNumber, int pageSize, String search) {
         log.info("Received request to list categories..");
-        return categoryService.listCategories(new PageRequest<>(
-                pageNumber, pageSize, language, search
-        ));
+        return categoryService.listCategories(
+                new PageRequest<>(pageNumber, pageSize, language, search),
+                AuthUtils.getUserIdFromSecurityContext()
+        );
     }
 
 }

--- a/src/main/java/com/cashflow/coredata/controller/category/CategoryController.java
+++ b/src/main/java/com/cashflow/coredata/controller/category/CategoryController.java
@@ -1,5 +1,7 @@
 package com.cashflow.coredata.controller.category;
 
+import org.springframework.web.bind.annotation.*;
+
 import com.cashflow.auth.core.utils.AuthUtils;
 import com.cashflow.commons.core.dto.request.BaseRequest;
 import com.cashflow.commons.core.dto.request.PageRequest;
@@ -12,7 +14,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
 
 import java.util.Locale;
 

--- a/src/main/java/com/cashflow/coredata/controller/category/ICategoryController.java
+++ b/src/main/java/com/cashflow/coredata/controller/category/ICategoryController.java
@@ -1,5 +1,6 @@
 package com.cashflow.coredata.controller.category;
 
+import com.cashflow.commons.core.dto.response.PageResponse;
 import com.cashflow.coredata.domain.dto.request.category.CategoryCreationRequest;
 import com.cashflow.coredata.domain.dto.response.CategoryResponse;
 import com.cashflow.exception.core.CashFlowException;
@@ -13,7 +14,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
-import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -72,7 +72,7 @@ public interface ICategoryController {
             @ApiResponse(responseCode = "200", description = "List of categories retrieved",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = CategoryResponse.class)))
     })
-    Page<CategoryResponse> listCategories(
+    PageResponse<CategoryResponse> listCategories(
             @RequestHeader(name = "Accept-Language", required = false, defaultValue = "en") Locale language,
             @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
             @RequestParam(name = "pageSize", required = false, defaultValue = "10") int pageSize,

--- a/src/main/java/com/cashflow/coredata/service/category/CategoryService.java
+++ b/src/main/java/com/cashflow/coredata/service/category/CategoryService.java
@@ -1,17 +1,22 @@
 package com.cashflow.coredata.service.category;
 
-import com.cashflow.auth.core.utils.AuthUtils;
+import com.cashflow.cache.service.CacheService;
 import com.cashflow.commons.core.dto.request.BaseRequest;
 import com.cashflow.commons.core.dto.request.PageRequest;
+import com.cashflow.commons.core.dto.response.PageResponse;
 import com.cashflow.coredata.domain.dto.request.category.CategoryCreationRequest;
 import com.cashflow.coredata.domain.dto.response.CategoryResponse;
 import com.cashflow.coredata.domain.entities.Category;
 import com.cashflow.coredata.domain.mapper.category.CategoryMapper;
 import com.cashflow.coredata.domain.validator.category.CategoryValidator;
 import com.cashflow.coredata.repository.category.CategoryRepository;
+import com.cashflow.coredata.utils.constants.cache.CacheNames;
 import com.cashflow.exception.core.CashFlowException;
+import jakarta.transaction.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.MessageSource;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -19,23 +24,30 @@ import org.springframework.stereotype.Service;
 @Service
 public class CategoryService implements ICategoryService {
 
-    Logger log = LoggerFactory.getLogger(CategoryService.class);
+    @Value("${cache.key-prefix}")
+    private String cacheKeyPrefix;
+
+    private final Logger log = LoggerFactory.getLogger(CategoryService.class);
 
     private final CategoryRepository categoryRepository;
 
     private final MessageSource messageSource;
 
+    private final CacheService cacheService;
+
     public CategoryService(final CategoryRepository categoryRepository,
-                           final MessageSource messageSource) {
+                           final MessageSource messageSource,
+                           final CacheService cacheService) {
         this.categoryRepository = categoryRepository;
         this.messageSource = messageSource;
+        this.cacheService = cacheService;
     }
 
     @Override
-    public CategoryResponse registerCategory(BaseRequest<CategoryCreationRequest> baseRequest) throws CashFlowException {
+    @Transactional
+    public CategoryResponse registerCategory(BaseRequest<CategoryCreationRequest> baseRequest, Long userId) throws CashFlowException {
 
         CategoryCreationRequest request = baseRequest.getRequest();
-        Long userId = AuthUtils.getUserIdFromSecurityContext();
 
         CategoryValidator.validateCategoryCreation(
                 categoryExistsByName(request.name(), userId),
@@ -50,6 +62,10 @@ public class CategoryService implements ICategoryService {
 
         log.info("Category created successfully!");
 
+        cacheService.invalidateCacheByPattern(
+                cacheKeyPrefix + CacheNames.CATEGORIES + CacheNames.SEPARATOR + userId + "-*"
+        );
+
         return CategoryMapper.mapToResponse(category);
 
     }
@@ -59,9 +75,12 @@ public class CategoryService implements ICategoryService {
     }
 
     @Override
-    public Page<CategoryResponse> listCategories(PageRequest<Void> request) {
+    @Cacheable(
+            value = CacheNames.CATEGORIES,
+            key = "#userId + '-' + #request.search + '-' + #request.pageable.pageNumber + '-' + #request.pageable.pageSize"
+    )
+    public PageResponse<CategoryResponse> listCategories(PageRequest<Void> request, Long userId) {
 
-        Long userId = AuthUtils.getUserIdFromSecurityContext();
         String search = request.getSearch();
 
         log.info("Searching user: {} categories with search: {}", userId, search);
@@ -70,7 +89,13 @@ public class CategoryService implements ICategoryService {
 
         log.info("Found {} categories!", response.getTotalElements());
 
-        return response;
+        return new PageResponse<>(
+                response.getContent(),
+                response.getPageable().getPageNumber(),
+                response.getPageable().getPageSize(),
+                response.getTotalElements(),
+                response.getTotalPages()
+        );
     }
 
 }

--- a/src/main/java/com/cashflow/coredata/service/category/ICategoryService.java
+++ b/src/main/java/com/cashflow/coredata/service/category/ICategoryService.java
@@ -2,14 +2,14 @@ package com.cashflow.coredata.service.category;
 
 import com.cashflow.commons.core.dto.request.BaseRequest;
 import com.cashflow.commons.core.dto.request.PageRequest;
+import com.cashflow.commons.core.dto.response.PageResponse;
 import com.cashflow.coredata.domain.dto.request.category.CategoryCreationRequest;
 import com.cashflow.coredata.domain.dto.response.CategoryResponse;
 import com.cashflow.exception.core.CashFlowException;
-import org.springframework.data.domain.Page;
 
 public interface ICategoryService {
 
-    CategoryResponse registerCategory(BaseRequest<CategoryCreationRequest> baseRequest) throws CashFlowException;
-    Page<CategoryResponse> listCategories(PageRequest<Void> request);
+    CategoryResponse registerCategory(BaseRequest<CategoryCreationRequest> baseRequest, Long userId) throws CashFlowException;
+    PageResponse<CategoryResponse> listCategories(PageRequest<Void> request, Long userId);
 
 }

--- a/src/main/java/com/cashflow/coredata/utils/constants/cache/CacheNames.java
+++ b/src/main/java/com/cashflow/coredata/utils/constants/cache/CacheNames.java
@@ -1,0 +1,10 @@
+package com.cashflow.coredata.utils.constants.cache;
+
+public class CacheNames {
+
+    private CacheNames() {}
+
+    public static final String SEPARATOR = "::";
+    public static final String CATEGORIES = "categories";
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,7 @@ server:
 # Spring Config
 
 spring:
+  # DataBase
   datasource:
     url: ${DATABASE_CONNECTION_STRING}
     username: ${DATABASE_USERNAME}
@@ -25,6 +26,15 @@ spring:
   autoconfigure:
     exclude:
       - org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration
+  # Cache
+  data:
+    redis:
+      url: ${REDIS_CONNECTION_STRING}
+
+cache:
+  key-prefix: "cashflow-core-data::"
+  duration:
+    categories: ${CACHE_DURATION_CATEGORIES}
 
 management:
   endpoints:

--- a/src/test/java/com/cashflow/coredata/controller/category/CategoryControllerTest.java
+++ b/src/test/java/com/cashflow/coredata/controller/category/CategoryControllerTest.java
@@ -1,21 +1,25 @@
 package com.cashflow.coredata.controller.category;
 
+import com.cashflow.auth.core.domain.authentication.CashFlowAuthentication;
+import com.cashflow.commons.core.dto.response.PageResponse;
 import com.cashflow.coredata.domain.dto.response.CategoryResponse;
 import com.cashflow.coredata.service.category.ICategoryService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import templates.category.CategoryTemplates;
+import templates.security.AuthenticationTemplates;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,11 +40,19 @@ class CategoryControllerTest {
 
     private static final String BASE_REQUEST_URL = "/core/category";
     private final CategoryResponse categoryResponse = CategoryTemplates.categoryResponse();
+    private final CashFlowAuthentication authentication = AuthenticationTemplates.cashFlowAuthentication();
 
     @Autowired
     CategoryControllerTest(final MockMvc mockMvc) {
         this.mockMvc = mockMvc;
         this.objectMapper = new ObjectMapper();
+    }
+
+    @BeforeEach
+    void setup() {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
     }
 
     @Test
@@ -49,7 +61,7 @@ class CategoryControllerTest {
 
         String jsonRequest = objectMapper.writeValueAsString(CategoryTemplates.categoryCreationRequest());
 
-        when(categoryService.registerCategory(any())).thenReturn(categoryResponse);
+        when(categoryService.registerCategory(any(), any())).thenReturn(categoryResponse);
 
         mockMvc.perform(MockMvcRequestBuilders.post(BASE_REQUEST_URL)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -62,9 +74,9 @@ class CategoryControllerTest {
     @SneakyThrows
     void givenParameter_whenListCategories_thenReturnCategoryResponsePage() {
 
-        Page<CategoryResponse> response = new PageImpl<>(new ArrayList<>(List.of(categoryResponse)));
+        PageResponse<CategoryResponse> response = new PageResponse<>(new ArrayList<>(List.of(categoryResponse)), 1, 0, 10, 1);
 
-        when(categoryService.listCategories(any())).thenReturn(response);
+        when(categoryService.listCategories(any(), any())).thenReturn(response);
 
         mockMvc.perform(MockMvcRequestBuilders.get(BASE_REQUEST_URL + "/list")
                 .contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/cashflow/coredata/repository/category/CategoryRepositoryTest.java
+++ b/src/test/java/com/cashflow/coredata/repository/category/CategoryRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.cashflow.coredata.repository.category;
 
+import com.cashflow.cache.service.CacheService;
 import com.cashflow.commons.core.dto.request.PageRequest;
 import com.cashflow.coredata.domain.dto.response.CategoryResponse;
 import org.junit.jupiter.api.Test;
@@ -7,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Locale;
 
@@ -19,6 +21,9 @@ class CategoryRepositoryTest {
 
     @Autowired
     private CategoryRepository categoryRepository;
+
+    @MockitoBean
+    private CacheService cacheService;
 
     private final PageRequest<Void> pageRequest = new PageRequest<>(0, 2, Locale.ENGLISH, "");
 

--- a/src/test/java/com/cashflow/coredata/service/category/CategoryServiceTest.java
+++ b/src/test/java/com/cashflow/coredata/service/category/CategoryServiceTest.java
@@ -1,6 +1,7 @@
 package com.cashflow.coredata.service.category;
 
 import com.cashflow.auth.core.domain.authentication.CashFlowAuthentication;
+import com.cashflow.cache.service.CacheService;
 import com.cashflow.commons.core.dto.request.BaseRequest;
 import com.cashflow.commons.core.dto.request.PageRequest;
 import com.cashflow.coredata.domain.dto.request.category.CategoryCreationRequest;
@@ -19,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.MessageSource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -32,7 +34,7 @@ import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
@@ -49,6 +51,9 @@ class CategoryServiceTest {
 
     @Mock
     private SecurityContext securityContext;
+
+    @Mock
+    private CacheService cacheService;
 
     private Locale locale;
 
@@ -77,7 +82,9 @@ class CategoryServiceTest {
         when(messageSource.getMessage("category.already.exists.title", null, locale)).thenReturn("Title");
         when(messageSource.getMessage("category.already.exists.message", null, locale)).thenReturn("Message");
 
-        CashFlowException exception = assertThrows(CashFlowException.class, () -> categoryService.registerCategory(baseRequest));
+        CashFlowException exception = assertThrows(CashFlowException.class, () -> categoryService.registerCategory(
+                baseRequest, Objects.requireNonNull(authentication.getCredentials()).id())
+        );
 
         assertAll(() -> {
             assertEquals(HttpStatus.BAD_REQUEST.value(), exception.getHttpStatusCode());
@@ -100,13 +107,16 @@ class CategoryServiceTest {
         ).thenReturn(0L);
         when(categoryRepository.save(any())).thenReturn(category);
 
-        CategoryResponse response = categoryService.registerCategory(baseRequest);
+        CategoryResponse response = categoryService.registerCategory(
+                baseRequest, Objects.requireNonNull(authentication.getCredentials()).id()
+        );
 
         assertAll(() -> {
             assertEquals(category.getId(), response.id());
             assertEquals(category.getColor(), response.color());
             assertEquals(category.getIcon(), response.icon());
             assertEquals(category.getName(), response.name());
+            verify(cacheService, times(1)).invalidateCacheByPattern(anyString());
         });
     }
 
@@ -114,7 +124,7 @@ class CategoryServiceTest {
     void givenPageRequest_whenListCategories_thenReturnCategoryResponsePage() {
 
         PageRequest<Void> pageRequest = new PageRequest<>(0, 10, locale, "search");
-        Page<CategoryResponse> pageResponse = new PageImpl<>(List.of(categoryResponse));
+        Page<CategoryResponse> pageResponse = new PageImpl<>(List.of(categoryResponse), Pageable.ofSize(20), 1);
 
         when(categoryRepository.findByNameLikeIgnoreCase(
                 "search",
@@ -123,8 +133,8 @@ class CategoryServiceTest {
         )).thenReturn(pageResponse);
 
         assertEquals(
-                pageResponse,
-                categoryService.listCategories(pageRequest)
+                categoryResponse,
+                categoryService.listCategories(pageRequest, Objects.requireNonNull(authentication.getCredentials()).id()).response().getFirst()
         );
 
     }

--- a/src/test/java/com/cashflow/coredata/service/category/CategoryServiceTest.java
+++ b/src/test/java/com/cashflow/coredata/service/category/CategoryServiceTest.java
@@ -33,8 +33,8 @@ import java.util.Locale;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,6 +12,9 @@ server:
 # Spring Config
 
 spring:
+  data:
+    redis:
+      url: redis://localhost:6379
   datasource:
     url: jdbc:h2:mem:testdb
     driver-class-name: org.h2.Driver
@@ -34,3 +37,10 @@ spring:
 jwt:
   secret: 76facb0e88956d6348e0bd2f0aac40d50c64696aab83c13110110d247479c047
   expiration: 3
+
+cashflow:
+  cache:
+    enabled: false
+cache:
+  duration:
+    categories: 10


### PR DESCRIPTION
## 💬 Description

Implementation of redis for caching categories list method to improve it's performance.

## 📋 What was done

- Added `cashflow-cache` lib;
- Added cache creation on list method;
- Added cache removal on create category method;

## 🛠️ Build

## 👷 Working Locally

### After listing cache is created

<img width="1900" height="1017" alt="GetOk" src="https://github.com/user-attachments/assets/ee3c3f8f-462d-4ee6-81ce-1a0d06c5a554" />
<img width="1353" height="707" alt="CacheCreated" src="https://github.com/user-attachments/assets/97a20d09-894b-4fa0-95d4-0d1eaf4ee8a2" />

### After creating a new category cache is deleted

<img width="1895" height="1021" alt="PostOk" src="https://github.com/user-attachments/assets/4c7eea08-412c-488a-9909-b97d9afe5353" />
<img width="1360" height="717" alt="CacheCleared" src="https://github.com/user-attachments/assets/7cfbda96-0697-456e-a72e-1a41d2505b71" />


## ✅ Issues Related

Closes #33 